### PR TITLE
Fix start issue on Linux 64 bits environments

### DIFF
--- a/scripts/sonarServer.ant
+++ b/scripts/sonarServer.ant
@@ -20,16 +20,16 @@
 		<property name="sonar.location" location="${sonar.install-location}/${sonar.name}-${sonar.version}" />
 		
 		<condition property="os.folder" value="windows-x86-64">
-			<os arch="amd64" />
+			<os family="windows" arch="amd64" />
+		</condition>
+		<condition property="os.folder" value="windows-x86-32">
+			<os family="windows" arch="x86" />
 		</condition>
 		<condition property="os.folder" value="linux-x86-32">
 			<os family="unix" arch="i386" />
 		</condition>
 		<condition property="os.folder" value="linux-x86-64">
 			<os family="unix" arch="amd64" />
-		</condition>
-		<condition property="os.folder" value="windows-x86-32">
-			<os family="windows" arch="x86" />
 		</condition>
 		<condition property="os.folder" value="macosx-universal-64">
 			<os family="mac" />


### PR DESCRIPTION
When running the script sonarServer.ant on a Linux 64 bits machine, it fails with the message:

> Cannot run program "/home/tdelhomenie/.sonar-server/sonarqube-5.6.7/bin/windows-x86-64/sonar.sh"

This change fixes the OS selection to make the server start correctly on Linux 64 bits environments.